### PR TITLE
Remove jq_no_number_highlight

### DIFF
--- a/syntax/jq.vim
+++ b/syntax/jq.vim
@@ -111,6 +111,4 @@ hi link jqString               String
 "hi link jqException            Exception
 "hi link jqInclude              Include
 "hi link jqDecorator            Define
-if !exists('jq_no_number_highlight')
-    hi link jqNumber               Number
-endif
+hi link jqNumber               Number


### PR DESCRIPTION
I think you made this for me, but I can accomplish the same thing by doing

```
hi Number ctermfg=whatever
```

or

```
hi link jqNumber Normal
```

in vimrc.
