### PR TITLE
[syntax] support all builtin operators

### DIFF
--- a/syntax/jq.vim
+++ b/syntax/jq.vim
@@ -73,7 +73,7 @@ syn region jqInterpolation matchgroup=jqInterpolationDelimiter
             \ contained contains=TOP
 
 " Operators
-syn match jqOperator /[-+=:<>]\+/
+syn match jqOperator /:\|\([-+*/%<>=]\|\/\/\)=\?\|[!|]=\|?\/\//
 "syn region jqRange matchgroup=jqSquareBracket start=+\[+ skip=+:+ end=+\]+
 
 " Errors


### PR DESCRIPTION
I improved the syntax to support more operators like `%` for modulo, `/` for division, `!=` for comparison operators, `?//` for destructuring alternative operator, etc.

|before|after|
|--|--|
|<img width="382" alt="Screen Shot 2019-05-16 at 13 26 32" src="https://user-images.githubusercontent.com/375258/57827290-c819ed00-77e1-11e9-9f68-41a75752ecd6.png">|<img width="380" alt="Screen Shot 2019-05-16 at 13 26 54" src="https://user-images.githubusercontent.com/375258/57827300-d10abe80-77e1-11e9-9a65-6921ba1ef6ac.png">|

