### PR TITLE
[syntax] support all builtin functions

### DIFF
--- a/syntax/jq.vim
+++ b/syntax/jq.vim
@@ -30,27 +30,41 @@ syntax region jqParentheses start=+(+ end=+)+ fold transparent
 
 " jq Functions
 syntax keyword jqFunction add all any arrays ascii_downcase floor
-syntax keyword jqFunction ascii_upcase booleans bsearch capture combinations
+syntax keyword jqFunction ascii_upcase booleans bsearch builtins capture combinations
 syntax keyword jqFunction \contains del delpaths endswith explode
 syntax keyword jqFunction finites first flatten format from_entries
 syntax keyword jqFunction fromdate fromdateiso8601 fromjson fromstream get_jq_origin
 syntax keyword jqFunction get_prog_origin get_search_list getpath gmtime group_by
-syntax keyword jqFunction gsub implode index indices infinite
+syntax keyword jqFunction gsub halt halt_error implode index indices infinite
 syntax keyword jqFunction input input_filename input_line_number inputs inside
-syntax keyword jqFunction isfinite isinfinite isnan isnormal iterables
+syntax keyword jqFunction isempty isfinite isinfinite isnan isnormal iterables
 syntax keyword jqFunction join keys keys_unsorted last leaf_paths
-syntax keyword jqFunction length limit ltrimstr map map_values
+syntax keyword jqFunction length limit localtime ltrimstr map map_values
 syntax keyword jqFunction match max max_by min min_by
 syntax keyword jqFunction mktime nan normals now
-syntax keyword jqFunction nulls numbers objects paths range
+syntax keyword jqFunction nulls numbers objects path paths range
 syntax keyword jqFunction recurse recurse_down repeat reverse rindex
 syntax keyword jqFunction rtrimstr scalars scalars_or_empty scan select
 syntax keyword jqFunction setpath sort sort_by split splits with_entries
-syntax keyword jqFunction startswith strftime strings strptime sub
+syntax keyword jqFunction startswith strflocaltime strftime strings strptime sub
 syntax keyword jqFunction test to_entries todate todateiso8601 tojson __loc__
 syntax keyword jqFunction tonumber tostream tostring transpose truncate_stream
 syntax keyword jqFunction unique unique_by until utf8bytelength values walk
 " TODO: $__loc__ is going to be a pain
+
+" jq Math Functions
+syntax keyword jqFunction acos acosh asin asinh atan atanh cbrt ceil cos cosh
+syntax keyword jqFunction erf erfc exp exp10 exp2 expm1 fabs floor gamma j0 j1
+syntax keyword jqFunction lgamma lgamma_r log log10 log1p log2 logb nearbyint
+syntax keyword jqFunction pow10 rint round significand sin sinh sqrt tan tanh
+syntax keyword jqFunction tgamma trunc y0 y1
+syntax keyword jqFunction atan2 copysign drem fdim fmax fmin fmod frexp hypot
+syntax keyword jqFunction jn ldexp modf nextafter nexttoward pow remainder
+syntax keyword jqFunction scalb scalbln yn
+syntax keyword jqFunction fma
+
+" jq SQL-style Operators
+syntax keyword jqFunction INDEX JOIN IN
 
 " Comments
 syntax match jqComment "#.*" contains=jqTodo


### PR DESCRIPTION
I improved the syntax file to support all the implemented builtin jq functions listed in `jq -n builtins`.