### PR TITLE
Fix escapes in jqString

### DIFF
--- a/syntax/jq.vim
+++ b/syntax/jq.vim
@@ -83,7 +83,7 @@ syn match jqNameDefinition /`[^`]\+`/ contained nextgroup=jqPostNameDefinition
 " Strings
 syn region jqError start=+'+ end=+'\|$\|[;)]\@=+
 syn region jqString matchgroup=jqQuote
-            \ start=+"+ skip=+\\"+ end=+"+
+            \ start=+"+ skip=+\\[\\"]+ end=+"+
             \ contains=@Spell,jqInterpolation
 syn region jqInterpolation matchgroup=jqInterpolationDelimiter
             \ start=+\%([^\\]\%(\\\\\)*\\\)\@<!\\(+ end=+)+


### PR DESCRIPTION
This PR fixes the string syntax by skipping `\\` in addition to `\"`. This fixes the broken syntax with strings containing `\\`.
```jq
def f: "\\";
def g: .;
```