### PR TITLE
Improve shebang

### DIFF
--- a/autoload/jq.vim
+++ b/autoload/jq.vim
@@ -1,0 +1,26 @@
+""
+" Refer https://github.com/vim/vim/blob/75e27d78f5370e7d2e0898326d9b080937e7b090/runtime/scripts.vim#L33-L71
+function! jq#shebang() abort
+    let s:line1 = getline(1)
+
+    if s:line1 =~# "^#!"
+        if s:line1 =~# '^#!\s*\S*\<env\s'
+            let s:line1 = substitute(s:line1, '\S\+=\S\+', '', 'g')
+            let s:line1 = substitute(s:line1, '\(-[iS]\|--ignore-environment\|--split-string\)', '', '')
+            let s:line1 = substitute(s:line1, '\<env\s\+', '', '')
+        endif
+        if s:line1 =~# '^#!\s*\a:[/\\]'
+            let s:name = substitute(s:line1, '^#!.*[/\\]\(\i\+\).*', '\1', '')
+        elseif s:line1 =~# '^#!.*\<env\>'
+            let s:name = substitute(s:line1, '^#!.*\<env\>\s\+\(\i\+\).*', '\1', '')
+        elseif s:line1 =~# '^#!\s*[^/\\ ]*\>\([^/\\]\|$\)'
+            let s:name = substitute(s:line1, '^#!\s*\([^/\\ ]*\>\).*', '\1', '')
+        else
+            let s:name = substitute(s:line1, '^#!\s*\S*[/\\]\(\i\+\).*', '\1', '')
+        endif
+        if s:name =~# '^jq'
+            set ft=jq
+        endif
+    endif
+endfunction
+" vim: et sw=4 ts=4 sts=4:

--- a/ftdetect/jq.vim
+++ b/ftdetect/jq.vim
@@ -2,9 +2,7 @@ function! s:DetectJQ()
     if did_filetype() && &filetype !=# 'conf'
         return
     endif
-    if getline(1) =~# '^#!.*\<jq\>'
-        set filetype=jq
-    endif
+    call jq#shebang()
 endfunction
 
 au BufNewFile,BufRead *.jq,.jqrc*,jqrc set filetype=jq


### PR DESCRIPTION
Original shebang detect is not robust. Even `#!/usr/bin/env -S sh -c 'echo jq $0'` will still be recognized to jq.
Now this code is referenced from vim's code which only recognize `#!/the/path/jq`, `#!/the/path/env jq` `#!/the/path/env -S jq XXX`, etc.
